### PR TITLE
fix (borrowing): rbac borrowing transaction list

### DIFF
--- a/Library_Management/server_side/views.py
+++ b/Library_Management/server_side/views.py
@@ -179,7 +179,10 @@ class BorrowedBookTransactionListView(APIView):
 
     def get(self, request):
         # Admins see all, users see their own
-        queryset = BorrowTransactions.objects.all().select_related('book', 'user') if request.user.is_staff else BorrowTransactions.objects.filter(user=request.user).select_related('book', 'user')
+        if request.user.is_staff:
+            queryset = BorrowTransactions.objects.all().select_related('book', 'user') 
+        else:
+            queryset = BorrowTransactions.objects.filter(user=request.user).select_related('book', 'user')
 
         status_filter = request.query_params.get('status')
         if status_filter:


### PR DESCRIPTION
Issue: returns only the user's list of borrowing transactions, regardless of role.

Fixed issue with returning a list of transactions based on user authorization.